### PR TITLE
Update format and add test for elevated privs

### DIFF
--- a/Get-Dat-WMI.ps1
+++ b/Get-Dat-WMI.ps1
@@ -1,8 +1,25 @@
+# Test if running with Elevated Privs else exit
+& {
+ $wid=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+ $prp=new-object System.Security.Principal.WindowsPrincipal($wid)
+ $adm=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+ $IsAdmin=$prp.IsInRole($adm)
+ if ($IsAdmin)
+ {
+    Write-host "Script Running With elevated Privladges" 
+ }
+ Else 
+ {
+    write-host "Script not running as Admin. please restart powershell with elevated privladges."
+    exit
+ }
+}
+
 # Set New Line format to support MS Notepad
 $NLCR = "`r`n"
 
 # Set Output path and Filename
-$OutFile = "C:\temp\ALL-DA-WMI-"+(get-date -Format MMddyyyy:HHmm)+".txt"
+$OutFile = "C:\temp\ALL-DA-WMI-"+(get-date -Format MMddyyyy_HHmm)+".txt"
 
 # Write Filename and Path to screen output 
 Write-Host Saving to -> $OutFile
@@ -11,9 +28,7 @@ Write-Host Saving to -> $OutFile
 ForEach ($i in (Get-WmiObject -List | Select-Object Name)) {
 
     # Write current class and time to output file
-    echo "Current Class-> " $i.Name + $NLCR + "Current Time: " + (get-date -Format MMddyyyy:HHmm) + $NLCR | Out-File $OutFile -Append -NoClobber
+    echo "Current Class-> " $i.Name $NLCR "Current Time: " (get-date -Format MMddyyyy_HHmm) $NLCR | Out-File $OutFile -Append -NoClobber
     
     # Get WMI Object Properties and output to file
     Get-WmiObject $i.Name | Out-File $OutFile -Append -NoClobber
-      
-}

--- a/Get-Dat-WMI.ps1
+++ b/Get-Dat-WMI.ps1
@@ -1,12 +1,19 @@
-﻿$OutFile = "C:\temp\ALL-DA-WMI-"+(get-date -Format MMddyyyy:HHmm)+".txt"
+# Set New Line format to support MS Notepad
+$NLCR = "`r`n"
 
+# Set Output path and Filename
+$OutFile = "C:\temp\ALL-DA-WMI-"+(get-date -Format MMddyyyy:HHmm)+".txt"
+
+# Write Filename and Path to screen output 
 Write-Host Saving to -> $OutFile
 
-$Data = ForEach ($i in (Get-WmiObject -List | Select-Object Name)) {
+# Get Current list of all WMI objects and itterate over name 
+ForEach ($i in (Get-WmiObject -List | Select-Object Name)) {
 
-    echo "Current Class-> " $i.Name | Out-File $OutFile -Append -NoClobber
+    # Write current class and time to output file
+    echo "Current Class-> " $i.Name + $NLCR + "Current Time: " + (get-date -Format MMddyyyy:HHmm) + $NLCR | Out-File $OutFile -Append -NoClobber
+    
+    # Get WMI Object Properties and output to file
     Get-WmiObject $i.Name | Out-File $OutFile -Append -NoClobber
       
 }
-
-$Data

--- a/Get-Dat-WMI.ps1
+++ b/Get-Dat-WMI.ps1
@@ -31,6 +31,6 @@ ForEach ($i in (Get-WmiObject -List | Select-Object Name)) {
     write-host $txt #| Out-File $OutFile -Append -NoClobber
     
     # Get WMI Object Properties and output to file
-    Get-WmiObject $i.Name | Out-File $OutFile -Append -NoClobber
+    Get-WmiObject -class $i.Name -EnableAllPrivileges -ErrorAction SilentlyContinue | Out-File $OutFile -Append -NoClobber
       
 }

--- a/Get-Dat-WMI.ps1
+++ b/Get-Dat-WMI.ps1
@@ -1,18 +1,17 @@
-# Test if running with Elevated Privs else exit
 & {
- $wid=[System.Security.Principal.WindowsIdentity]::GetCurrent()
- $prp=new-object System.Security.Principal.WindowsPrincipal($wid)
- $adm=[System.Security.Principal.WindowsBuiltInRole]::Administrator
- $IsAdmin=$prp.IsInRole($adm)
- if ($IsAdmin)
- {
-    Write-host "Script Running With elevated Privladges" 
- }
- Else 
- {
-    write-host "Script not running as Admin. please restart powershell with elevated privladges."
-    exit
- }
+     $wid=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+     $prp=new-object System.Security.Principal.WindowsPrincipal($wid)
+     $adm=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+     $IsAdmin=$prp.IsInRole($adm)
+     if ($IsAdmin)
+     {
+        Write-host "Script Running With elevated Privladges" 
+     }
+     Else 
+     {
+        write-host "Script not running as Admin. please restart powershell with elevated privladges."
+        exit
+     }
 }
 
 # Set New Line format to support MS Notepad
@@ -28,7 +27,10 @@ Write-Host Saving to -> $OutFile
 ForEach ($i in (Get-WmiObject -List | Select-Object Name)) {
 
     # Write current class and time to output file
-    echo "Current Class-> " $i.Name $NLCR "Current Time: " (get-date -Format MMddyyyy_HHmm) $NLCR | Out-File $OutFile -Append -NoClobber
+    $txt= "Current Class-> "+$i.Name+$NLCR+"Current Time: "+(get-date -Format MMddyyyy_HHmm)+$NLCR 
+    write-host $txt #| Out-File $OutFile -Append -NoClobber
     
     # Get WMI Object Properties and output to file
     Get-WmiObject $i.Name | Out-File $OutFile -Append -NoClobber
+      
+}


### PR DESCRIPTION
Added inline comments
updated file name in $OutFile to support Legacy Windows OS's that do not support ":" in file name
Added Test to validate powershell is running with elevated Privs (backward compatible with powershell 2.0) 